### PR TITLE
Update isTableMigratedToMd5 function in HashLongtextFields.php (reduce Memory Usage)

### DIFF
--- a/app/code/community/Ess/M2ePro/sql/Update/y20_m07/HashLongtextFields.php
+++ b/app/code/community/Ess/M2ePro/sql/Update/y20_m07/HashLongtextFields.php
@@ -79,6 +79,7 @@ SQL
             ->select()
             ->from($this->_installer->getFullTableName($tableName), $column)
             ->where("`{$column}` IS NOT NULL")
+            ->limit(1)
             ->query()
             ->fetchColumn();
 


### PR DESCRIPTION
Update isTableMigratedToMd5 function to reduce memory usage for big tables